### PR TITLE
New ABI providers

### DIFF
--- a/evmscript_parser/core/decode/ABI/combine.py
+++ b/evmscript_parser/core/decode/ABI/combine.py
@@ -1,0 +1,52 @@
+"""
+Combined ABI provider, APIEtherscan with local directory.
+"""
+import logging
+
+from typing import Optional
+
+from .base import ABI_T
+from .etherscan import ABIProviderEtherscanApi
+from .local import ABIProviderLocal
+
+from evmscript_parser.core.exceptions import (
+    ABIEtherscanNetworkError, ABIEtherscanStatusCode
+)
+
+
+class ABIProviderCombined(
+    ABIProviderLocal, ABIProviderEtherscanApi
+):
+    """
+    Combined way of getting ABI
+    """
+
+    def __init__(
+            self,
+            api_key: str, interface_directory: str,
+            specific_net: Optional[str] = None,
+            retries: int = 5, proxy_punching: bool = True
+    ):
+        """Initialize Etherscan API and local providers."""
+        ABIProviderEtherscanApi.__init__(
+            self, api_key, specific_net, retries, proxy_punching
+        )
+        ABIProviderLocal.__init__(
+            self, interface_directory
+        )
+
+    def get_abi(self, address: str, *args, **kwargs) -> ABI_T:
+        """Return ABI."""
+        try:
+            return ABIProviderEtherscanApi.get_abi(
+                self, address, *args, **kwargs
+            )
+        except (ABIEtherscanNetworkError, ABIEtherscanStatusCode) as err:
+            logging.exception(
+                f'ABIProviderCombined: '
+                f'Getting ABI through Etherscan API failed: '
+                f'{repr(err)}')
+
+        return ABIProviderLocal.get_abi(
+            *args, **kwargs
+        )

--- a/evmscript_parser/core/decode/ABI/etherscan.py
+++ b/evmscript_parser/core/decode/ABI/etherscan.py
@@ -90,7 +90,7 @@ def _send_query(
         try:
             response.raise_for_status()
         except requests.HTTPError as err:
-            raise ABIEtherscanNetworkError(repr(err))
+            raise ABIEtherscanNetworkError(str(err)) from err
 
         data = response.json()
 
@@ -203,8 +203,8 @@ class ABIProviderEtherscanApi(ABIProvider):
         :param args: None
         :param kwargs: None
         :return: List[Dict[str, Any]], ABI description.
-        :exception HTTPError in case of error at network layer.
-        :exception RuntimeError in case of error in api calls.
+        :exception ABIEtherscanNetworkError in case of error at network layer.
+        :exception ABIEtherscanStatusCode in case of error in api calls.
         """
         abi = get_abi(
             self._api_key, address, self._specific_net, self._retries

--- a/evmscript_parser/core/decode/ABI/local.py
+++ b/evmscript_parser/core/decode/ABI/local.py
@@ -1,0 +1,37 @@
+"""
+Provider for getting ABI from local .json files.
+"""
+import os
+import glob
+import json
+
+from functools import lru_cache
+
+from .base import ABIProvider, ABI_T
+
+
+@lru_cache(maxsize=128)
+def _read_interfaces(directory: str) -> ABI_T:
+    """Read all json files from directory."""
+    return sum(
+        [
+            json.load(interface)
+            for interface
+            in glob.glob(os.path.join(directory, '*.json'))
+        ],
+        []
+    )
+
+
+class ABIProviderLocal(ABIProvider):
+    """
+    Store ABI specification get from local directory.
+    """
+
+    def __init__(self, interface_directory: str):
+        """Get cached or read ABI from directory."""
+        self._abi = _read_interfaces(interface_directory)
+
+    def get_abi(self, *args, **kwargs) -> ABI_T:
+        """Return ABI"""
+        return self._abi

--- a/evmscript_parser/core/decode/action.py
+++ b/evmscript_parser/core/decode/action.py
@@ -3,7 +3,7 @@ Decoding functions callings to human-readable format.
 """
 import web3
 
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
 
 from sha3 import keccak_256
 
@@ -59,7 +59,7 @@ def _gather_types(inputs: List[Dict[str, Any]]) -> List[str]:
     ]
 
 
-def with_decoded_signatures(
+def with_encoded_signatures(
         contract_abi: ABI_T
 ) -> METHOD_ABI_MAPPING_T:
     """Create mapping from function signatures to function descriptions."""
@@ -90,7 +90,7 @@ def with_decoded_signatures(
 def decode_function_call(
         contract_address: str, function_signature: str, call_data: str,
         abi_provider: ABIProvider
-) -> Call:
+) -> Optional[Call]:
     """
     Decode function call.
 
@@ -105,9 +105,11 @@ def decode_function_call(
         address=contract_address, singature=function_signature
     )
 
-    function_description = with_decoded_signatures(
+    function_description = with_encoded_signatures(
         abi
-    ).get(function_signature, None)
+    ).get(
+        function_signature, None
+    )
 
     if function_description is None:
         return function_description


### PR DESCRIPTION
- Add `ABIProvider` for getting specification from local directory of json file with interfaces.
- Add `ABIProvider` for combined getting specification from Etherscan API or from local directory in the case of failed API calling.